### PR TITLE
[CHORE] new_release: correct nacos-only label name + add edit-mode hint

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.yml
+++ b/.github/ISSUE_TEMPLATE/new_release.yml
@@ -12,7 +12,7 @@ body:
         **Instructions:**
         1. Update the title to match the release date: `[RELEASE] stg-YYYYMMDD`
         2. PRs must already be merged to `develop` branch
-        3. If any services need only Nacos config updated (without code change), select them from the **Nacos Change Only Services** dropdown below, then add label `nacos-sync` to trigger the sync workflow
+        3. If any services need only Nacos config updated (without code change), select them from the **Nacos Change Only Services** dropdown below, then add label `release:nacos-only:stg` or `release:nacos-only:prod` to trigger the sync workflow
         4. Add label `release:plan` to trigger the automation
         5. The workflow will automatically:
            - Create branch `stg-YYYYMMDD` from `stg`
@@ -26,9 +26,8 @@ body:
     attributes:
       label: Nacos Change Only Services
       description: |
-        Select services that need nacos config updated in PROD **without** changing their code version.
-        After selecting, add label `nacos-sync` to this issue to trigger the sync workflow.
-        The workflow will deploy nacos config and automatically clear this dropdown when done.
+        Services that need nacos config updated **without** code change. After selecting, add label `release:nacos-only:stg` or `release:nacos-only:prod` to trigger the sync. Dropdown auto-clears on success.
+        On re-edit (no dropdown UI after issue is created), replace `_No response_` with comma-separated services, e.g. `ninja-chat-service, ninja-user-service`.
       multiple: true
       options:
         - ninja-agent-store-service


### PR DESCRIPTION
## Summary

Two small text fixes to `.github/ISSUE_TEMPLATE/new_release.yml` so the form copy matches the actual nacos-only flow:

1. The dropdown's instructions and the description both said *add label `nacos-sync` to trigger*. The real labels are `release:nacos-only:stg` and `release:nacos-only:prod`. Update both occurrences.

2. After the issue is created, GitHub no longer renders the dropdown UI: an `Edit` user only sees raw markdown like

   ```markdown
   ### Nacos Change Only Services

   _No response_
   ```

   Add a one-line example to the dropdown description telling people to replace `_No response_` with comma-separated services, e.g. `ninja-chat-service, ninja-user-service`. This mirrors the same hint that gitops `nacos-only-sync.yml` re-emits below `_No response_` after a successful sync (aidd-agex/gitops#882), so first-time creators and re-edit users see the same minimal example.

## Test plan

- [ ] Open a new release issue from the template -> verify the dropdown's helper text shows the corrected label and the comma-separated example.

Made with [Cursor](https://cursor.com)